### PR TITLE
Fix mistakes wrs to spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-uBITX firmware, written for the Raduino/Arduino control of uBITX transceigers
+uBITX firmware, written for the Raduino/Arduino control of uBITX tranceivers
 
 Copyright (C) 2017,  Ashhar Farhan
 

--- a/ubitx_20/ubitx_20.ino
+++ b/ubitx_20/ubitx_20.ino
@@ -1,33 +1,33 @@
 /**
  * This source file is under General Public License version 3.
- * 
+ *
  * This verision uses a built-in Si5351 library
- * Most source code are meant to be understood by the compilers and the computers. 
- * Code that has to be hackable needs to be well understood and properly documented. 
- * Donald Knuth coined the term Literate Programming to indicate code that is written be 
+ * Most source code are meant to be understood by the compilers and the computers.
+ * Code that has to be hackable needs to be well understood and properly documented.
+ * Donald Knuth coined the term Literate Programming to indicate code that is written be
  * easily read and understood.
- * 
+ *
  * The Raduino is a small board that includes the Arduin Nano, a 16x2 LCD display and
  * an Si5351a frequency synthesizer. This board is manufactured by Paradigm Ecomm Pvt Ltd
- * 
- * To learn more about Arduino you may visit www.arduino.cc. 
- * 
- * The Arduino works by starts executing the code in a function called setup() and then it 
+ *
+ * To learn more about Arduino you may visit www.arduino.cc.
+ *
+ * The Arduino works by starts executing the code in a function called setup() and then it
  * repeatedly keeps calling loop() forever. All the initialization code is kept in setup()
  * and code to continuously sense the tuning knob, the function button, transmit/receive,
  * etc is all in the loop() function. If you wish to study the code top down, then scroll
  * to the bottom of this file and read your way up.
- * 
- * Below are the libraries to be included for building the Raduino 
- * The EEPROM library is used to store settings like the frequency memory, caliberation data, 
+ *
+ * Below are the libraries to be included for building the Raduino
+ * The EEPROM library is used to store settings like the frequency memory, caliberation data,
  * callsign etc .
  *
  *  The main chip which generates upto three oscillators of various frequencies in the
- *  Raduino is the Si5351a. To learn more about Si5351a you can download the datasheet 
- *  from www.silabs.com although, strictly speaking it is not a requirment to understand this code. 
- *  Instead, you can look up the Si5351 library written by xxx, yyy. You can download and 
+ *  Raduino is the Si5351a. To learn more about Si5351a you can download the datasheet
+ *  from www.silabs.com although, strictly speaking it is not a requirment to understand this code.
+ *  Instead, you can look up the Si5351 library written by xxx, yyy. You can download and
  *  install it from www.url.com to complile this file.
- *  The Wire.h library is used to talk to the Si5351 and we also declare an instance of 
+ *  The Wire.h library is used to talk to the Si5351 and we also declare an instance of
  *  Si5351 object to control the clocks.
  */
 #include <Wire.h>
@@ -50,19 +50,19 @@
  * There are two sets of completely programmable pins on the Raduino.
  * First, on the top of the board, in line with the LCD connector is an 8-pin connector
  * that is largely meant for analog inputs and front-panel control. It has a regulated 5v output,
- * ground and six pins. Each of these six pins can be individually programmed 
- * either as an analog input, a digital input or a digital output. 
- * The pins are assigned as follows (left to right, display facing you): 
+ * ground and six pins. Each of these six pins can be individually programmed
+ * either as an analog input, a digital input or a digital output.
+ * The pins are assigned as follows (left to right, display facing you):
  *      Pin 1 (Violet), A7, SPARE
  *      Pin 2 (Blue),   A6, KEYER (DATA)
- *      Pin 3 (Green), +5v 
+ *      Pin 3 (Green), +5v
  *      Pin 4 (Yellow), Gnd
  *      Pin 5 (Orange), A3, PTT
  *      Pin 6 (Red),    A2, F BUTTON
  *      Pin 7 (Brown),  A1, ENC B
  *      Pin 8 (Black),  A0, ENC A
- *Note: A5, A4 are wired to the Si5351 as I2C interface 
- *       *     
+ *Note: A5, A4 are wired to the Si5351 as I2C interface
+ *       *
  * Though, this can be assigned anyway, for this application of the Arduino, we will make the following
  * assignment
  * A2 will connect to the PTT line, which is the usually a part of the mic connector
@@ -79,17 +79,17 @@
 #define ANALOG_KEYER (A6)
 #define ANALOG_SPARE (A7)
 
-/** 
+/**
  * The Raduino board is the size of a standard 16x2 LCD panel. It has three connectors:
- * 
- * First, is an 8 pin connector that provides +5v, GND and six analog input pins that can also be 
+ *
+ * First, is an 8 pin connector that provides +5v, GND and six analog input pins that can also be
  * configured to be used as digital input or output pins. These are referred to as A0,A1,A2,
- * A3,A6 and A7 pins. The A4 and A5 pins are missing from this connector as they are used to 
- * talk to the Si5351 over I2C protocol. 
- * 
+ * A3,A6 and A7 pins. The A4 and A5 pins are missing from this connector as they are used to
+ * talk to the Si5351 over I2C protocol.
+ *
  * Second is a 16 pin LCD connector. This connector is meant specifically for the standard 16x2
  * LCD display in 4 bit mode. The 4 bit mode requires 4 data lines and two control lines to work:
- * Lines used are : RESET, ENABLE, D4, D5, D6, D7 
+ * Lines used are : RESET, ENABLE, D4, D5, D6, D7
  * We include the library and declare the configuration of the LCD panel too
  */
 
@@ -98,24 +98,24 @@ LiquidCrystal lcd(8,9,10,11,12,13);
 
 /**
  * The Arduino, unlike C/C++ on a regular computer with gigabytes of RAM, has very little memory.
- * We have to be very careful with variables that are declared inside the functions as they are 
+ * We have to be very careful with variables that are declared inside the functions as they are
  * created in a memory region called the stack. The stack has just a few bytes of space on the Arduino
  * if you declare large strings inside functions, they can easily exceed the capacity of the stack
- * and mess up your programs. 
- * We circumvent this by declaring a few global buffers as  kitchen counters where we can 
+ * and mess up your programs.
+ * We circumvent this by declaring a few global buffers as  kitchen counters where we can
  * slice and dice our strings. These strings are mostly used to control the display or handle
  * the input and output from the USB port. We must keep a count of the bytes used while reading
  * the serial port as we can easily run out of buffer space. This is done in the serial_in_count variable.
  */
-char c[30], b[30];      
+char c[30], b[30];
 char printBuff[2][17];  //mirrors what is showing on the two lines of the display
 int count = 0;          //to generally count ticks, loops, etc
 
-/** 
+/**
  *  The second set of 16 pins on the Raduino's bottom connector are have the three clock outputs and the digital lines to control the rig.
  *  This assignment is as follows :
  *    Pin   1   2    3    4    5    6    7    8    9    10   11   12   13   14   15   16
- *         GND +5V CLK0  GND  GND  CLK1 GND  GND  CLK2  GND  D2   D3   D4   D5   D6   D7  
+ *         GND +5V CLK0  GND  GND  CLK1 GND  GND  CLK2  GND  D2   D3   D4   D5   D6   D7
  *  These too are flexible with what you may do with them, for the Raduino, we use them to :
  *  - TX_RX line : Switches between Transmit and Receive after sensing the PTT or the morse keyer
  *  - CW_KEY line : turns on the carrier for CW
@@ -143,25 +143,25 @@ int count = 0;          //to generally count ticks, loops, etc
 
 /**
  * The uBITX is an upconnversion transceiver. The first IF is at 45 MHz.
- * The first IF frequency is not exactly at 45 Mhz but about 5 khz lower,
- * this shift is due to the loading on the 45 Mhz crystal filter by the matching
+ * The first IF frequency is not exactly at 45 MHz but about 5 kHz lower,
+ * this shift is due to the loading on the 45 MHz crystal filter by the matching
  * L-network used on it's either sides.
- * The first oscillator works between 48 Mhz and 75 MHz. The signal is subtracted
- * from the first oscillator to arriive at 45 Mhz IF. Thus, it is inverted : LSB becomes USB
+ * The first oscillator works between 48 MHz and 75 MHz. The signal is subtracted
+ * from the first oscillator to arriive at 45 MHz IF. Thus, it is inverted : LSB becomes USB
  * and USB becomes LSB.
- * The second IF of 12 Mhz has a ladder crystal filter. If a second oscillator is used at 
- * 57 Mhz, the signal is subtracted FROM the oscillator, inverting a second time, and arrives 
- * at the 12 Mhz ladder filter thus doouble inversion, keeps the sidebands as they originally were.
- * If the second oscillator is at 33 Mhz, the oscilaltor is subtracated from the signal, 
+ * The second IF of 12 MHz has a ladder crystal filter. If a second oscillator is used at
+ * 57 MHz, the signal is subtracted FROM the oscillator, inverting a second time, and arrives
+ * at the 12 MHz ladder filter thus doouble inversion, keeps the sidebands as they originally were.
+ * If the second oscillator is at 33 MHz, the oscilaltor is subtracated from the signal,
  * thus keeping the signal's sidebands inverted. The USB will become LSB.
  * We use this technique to switch sidebands. This is to avoid placing the lsbCarrier close to
- * 12 MHz where its fifth harmonic beats with the arduino's 16 Mhz oscillator's fourth harmonic
+ * 12 MHz where its fifth harmonic beats with the arduino's 16 MHz oscillator's fourth harmonic
  */
 
-// the second oscillator should ideally be at 57 MHz, however, the crystal filter's center frequency 
+// the second oscillator should ideally be at 57 MHz, however, the crystal filter's center frequency
 // is shifted down a little due to the loading from the impedance matching L-networks on either sides
 #define SECOND_OSC_USB (56995000l)
-#define SECOND_OSC_LSB (32995000l) 
+#define SECOND_OSC_LSB (32995000l)
 //these are the two default USB and LSB frequencies. The best frequencies depend upon your individual taste and filter shape
 #define INIT_USB_FREQ   (11996500l)
 // limits the tuning and working range of the ubitx between 3 MHz and 30 MHz
@@ -189,7 +189,7 @@ boolean txCAT = false;        //turned on if the transmitting due to a CAT comma
 char inTx = 0;                //it is set to 1 if in transmit mode (whatever the reason : cw, ptt or cat)
 char splitOn = 0;             //working split, uses VFO B as the transmit frequency, (NOT IMPLEMENTED YET)
 char keyDown = 0;             //in cw mode, denotes the carrier is being transmitted
-char isUSB = 0;               //upper sideband was selected, this is reset to the default for the 
+char isUSB = 0;               //upper sideband was selected, this is reset to the default for the
                               //frequency when it crosses the frequency border of 10 MHz
 byte menuOn = 0;              //set to 1 when the menu is being displayed, if a menu item sets it to zero, the menu is exited
 unsigned long cwTimeout = 0;  //milliseconds to go before the cw transmit line is released and the radio goes back to rx mode
@@ -198,28 +198,28 @@ unsigned char txFilter = 0;   //which of the four transmit filters are in use
 boolean modeCalibrate = false;//this mode of menus shows extended menus to calibrate the oscillators and choose the proper
                               //beat frequency
 /**
- * Below are the basic functions that control the uBitx. Understanding the functions before 
+ * Below are the basic functions that control the uBitx. Understanding the functions before
  * you start hacking around
  */
 
 /**
  * Select the properly tx harmonic filters
  * The four harmonic filters use only three relays
- * the four LPFs cover 30-21 Mhz, 18 - 14 Mhz, 7-10 MHz and 3.5 to 5 Mhz
- * Briefly, it works like this, 
+ * the four LPFs cover 30-21 MHz, 18 - 14 MHz, 7-10 MHz and 3.5 to 5 MHz
+ * Briefly, it works like this,
  * - When KT1 is OFF, the 'off' position routes the PA output through the 30 MHz LPF
  * - When KT1 is ON, it routes the PA output to KT2. Which is why you will see that
  *   the KT1 is on for the three other cases.
  * - When the KT1 is ON and KT2 is off, the off position of KT2 routes the PA output
- *   to 18 MHz LPF (That also works for 14 Mhz) 
+ *   to 18 MHz LPF (That also works for 14 MHz)
  * - When KT1 is On, KT2 is On, it routes the PA output to KT3
- * - KT3, when switched on selects the 7-10 Mhz filter
- * - KT3 when switched off selects the 3.5-5 Mhz filter
+ * - KT3, when switched on selects the 7-10 MHz filter
+ * - KT3 when switched off selects the 3.5-5 MHz filter
  * See the circuit to understand this
  */
 
 void setTXFilters(unsigned long freq){
-  
+
   if (freq > 21000000L){  // the default filter is with 35 MHz cut-off
     digitalWrite(TX_LPF_A, 0);
     digitalWrite(TX_LPF_B, 0);
@@ -233,31 +233,31 @@ void setTXFilters(unsigned long freq){
   else if (freq > 7000000L){
     digitalWrite(TX_LPF_A, 1);
     digitalWrite(TX_LPF_B, 1);
-    digitalWrite(TX_LPF_C, 0);    
+    digitalWrite(TX_LPF_C, 0);
   }
   else {
     digitalWrite(TX_LPF_A, 1);
     digitalWrite(TX_LPF_B, 1);
-    digitalWrite(TX_LPF_C, 1);    
+    digitalWrite(TX_LPF_C, 1);
   }
 }
 
 /**
- * This is the most frequently called function that configures the 
+ * This is the most frequently called function that configures the
  * radio to a particular frequeny, sideband and sets up the transmit filters
- * 
+ *
  * The transmit filter relays are powered up only during the tx so they dont
- * draw any current during rx. 
- * 
+ * draw any current during rx.
+ *
  * The carrier oscillator of the detector/modulator is permanently fixed at
  * uppper sideband. The sideband selection is done by placing the second oscillator
- * either 12 Mhz below or above the 45 Mhz signal thereby inverting the sidebands 
+ * either 12 MHz below or above the 45 MHz signal thereby inverting the sidebands
  * through mixing of the second local oscillator.
  */
- 
+
 void setFrequency(unsigned long f){
   uint64_t osc_f;
- 
+
   setTXFilters(f);
 
   if (isUSB){
@@ -268,7 +268,7 @@ void setFrequency(unsigned long f){
     si5351bx_setfreq(2, SECOND_OSC_LSB + usbCarrier + f);
     si5351bx_setfreq(1, SECOND_OSC_LSB);
   }
-  
+
   frequency = f;
 }
 
@@ -277,12 +277,12 @@ void setFrequency(unsigned long f){
  * put the uBitx in tx mode. It takes care of rit settings, sideband settings
  * Note: In cw mode, doesnt key the radio, only puts it in tx mode
  */
- 
+
 void startTx(byte txMode){
-  unsigned long tx_freq = 0;  
+  unsigned long tx_freq = 0;
   digitalWrite(TX_RX, 1);
   inTx = 1;
-  
+
   if (ritOn){
     //save the current as the rx frequency
     ritRxFrequency = frequency;
@@ -300,7 +300,7 @@ void startTx(byte txMode){
     if (isUSB)
       si5351bx_setfreq(2, frequency + sideTone);
     else
-      si5351bx_setfreq(2, frequency - sideTone); 
+      si5351bx_setfreq(2, frequency - sideTone);
   }
   updateDisplay();
 }
@@ -315,7 +315,7 @@ void stopTx(){
     setFrequency(ritRxFrequency);
   else
     setFrequency(frequency);
-  
+
   updateDisplay();
 }
 
@@ -349,16 +349,16 @@ void ritDisable(){
  * flip the T/R line to T and update the display to denote transmission
  */
 
-void checkPTT(){	
+void checkPTT(){
   //we don't check for ptt when transmitting cw
   if (cwTimeout > 0)
     return;
-    
+
   if (digitalRead(PTT) == 0 && inTx == 0){
     startTx(TX_SSB);
     delay(50); //debounce the PTT
   }
-	
+
   if (digitalRead(PTT) == 1 && inTx == 1)
     stopTx();
 }
@@ -372,7 +372,7 @@ void checkButton(){
   delay(50);
   if (!btnDown()) //debounce
     return;
- 
+
   doMenu();
   //wait for the button to go up again
   while(btnDown())
@@ -383,8 +383,8 @@ void checkButton(){
 
 /**
  * The tuning jumps by 50 Hz on each step when you tune slowly
- * As you spin the encoder faster, the jump size also increases 
- * This way, you can quickly move to another band by just spinning the 
+ * As you spin the encoder faster, the jump size also increases
+ * This way, you can quickly move to another band by just spinning the
  * tuning knob
  */
 
@@ -395,7 +395,7 @@ void doTuning(){
   s = enc_read();
   if (s){
     prev_freq = frequency;
-    
+
     if (s > 10)
       frequency += 200000l;
     if (s > 7)
@@ -416,10 +416,10 @@ void doTuning(){
       frequency -= 10000l;
     else
       frequency -= 200000l;
-      
+
     if (prev_freq < 10000000l && frequency > 10000000l)
       isUSB = true;
-      
+
     if (prev_freq > 10000000l && frequency < 10000000l)
       isUSB = false;
 
@@ -429,11 +429,11 @@ void doTuning(){
 }
 
 /**
- * RIT only steps back and forth by 100 hz at a time
+ * RIT only steps back and forth by 100 Hz at a time
  */
 void doRIT(){
   unsigned long newFreq;
- 
+
   int knob = enc_read();
   unsigned long old_freq = frequency;
 
@@ -441,7 +441,7 @@ void doRIT(){
     frequency -= 100l;
   else if (knob > 0)
     frequency += 100;
- 
+
   if (old_freq != frequency){
     setFrequency(frequency);
     updateDisplay();
@@ -449,14 +449,14 @@ void doRIT(){
 }
 
 /**
- * The settings are read from EEPROM. The first time around, the values may not be 
- * present or out of range, in this case, some intelligent defaults are copied into the 
+ * The settings are read from EEPROM. The first time around, the values may not be
+ * present or out of range, in this case, some intelligent defaults are copied into the
  * variables.
  */
 void initSettings(){
   //read the settings from the eeprom and restore them
   //if the readings are off, then set defaults
-  EEPROM.get(MASTER_CAL, calibration); 
+  EEPROM.get(MASTER_CAL, calibration);
   EEPROM.get(USB_CAL, usbCarrier);
   EEPROM.get(VFO_A, vfoA);
   EEPROM.get(VFO_B, vfoB);
@@ -467,12 +467,12 @@ void initSettings(){
   if (vfoA > 35000000l || 3500000l > vfoA)
      vfoA = 7150000l;
   if (vfoB > 35000000l || 3500000l > vfoB)
-     vfoB = 14150000l;  
-  if (sideTone < 100 || 2000 < sideTone) 
+     vfoB = 14150000l;
+  if (sideTone < 100 || 2000 < sideTone)
     sideTone = 800;
-  if (cwSpeed < 10 || 1000 < cwSpeed) 
+  if (cwSpeed < 10 || 1000 < cwSpeed)
     cwSpeed = 100;
-    
+
 }
 
 void initPorts(){
@@ -483,7 +483,7 @@ void initPorts(){
   pinMode(ENC_A, INPUT_PULLUP);
   pinMode(ENC_B, INPUT_PULLUP);
   pinMode(FBUTTON, INPUT_PULLUP);
-  
+
   //configure the function button to use the external pull-up
 //  pinMode(FBUTTON, INPUT);
 //  digitalWrite(FBUTTON, HIGH);
@@ -491,9 +491,9 @@ void initPorts(){
   pinMode(PTT, INPUT_PULLUP);
   pinMode(ANALOG_KEYER, INPUT_PULLUP);
 
-  pinMode(CW_TONE, OUTPUT);  
+  pinMode(CW_TONE, OUTPUT);
   digitalWrite(CW_TONE, 0);
-  
+
   pinMode(TX_RX,OUTPUT);
   digitalWrite(TX_RX, 0);
 
@@ -511,17 +511,17 @@ void initPorts(){
 void setup()
 {
   Serial.begin(9600);
-  
+
   lcd.begin(16, 2);
 
-  //we print this line so this shows up even if the raduino 
+  //we print this line so this shows up even if the raduino
   //crashes later in the code
-  printLine1("uBITX v0.20"); 
+  printLine1("uBITX v0.20");
   delay(500);
 
   initMeter(); //not used in this build
   initSettings();
-  initPorts();     
+  initPorts();
   initOscillators();
 
   frequency = vfoA;
@@ -538,21 +538,21 @@ void setup()
  */
 
 byte flasher = 0;
-void loop(){ 
-  
-  cwKeyer(); 
+void loop(){
+
+  cwKeyer();
   if (!txCAT)
     checkPTT();
   checkButton();
 
-  //tune only when not tranmsitting 
+  //tune only when not tranmsitting
   if (!inTx){
     if (ritOn)
       doRIT();
-    else 
+    else
       doTuning();
   }
-  
+
   //we check CAT after the encoder as it might put the radio into TX
   checkCAT();
 }

--- a/ubitx_20/ubitx_cat.ino
+++ b/ubitx_20/ubitx_cat.ino
@@ -1,12 +1,12 @@
 /**
  * The CAT protocol is used by many radios to provide remote control to comptuers through
  * the serial port.
- * 
+ *
  * This is very much a work in progress. Parts of this code have been liberally
  * borrowed from other GPLicensed works like hamlib.
- * 
- * WARNING : This is an unstable version and it has worked with fldigi, 
- * it gives time out error with WSJTX 1.8.0  
+ *
+ * WARNING : This is an unstable version and it has worked with fldigi,
+ * it gives time out error with WSJTX 1.8.0
  */
 
 // The next 4 functions are needed to implement the CAT protocol, which
@@ -35,7 +35,7 @@ byte getLowNibble(byte b) {
 }
 
 // Takes a number and produces the requested number of decimal digits, staring
-// from the least significant digit.  
+// from the least significant digit.
 //
 void getDecimalDigits(unsigned long number,byte* result,int digits) {
   for (int i = 0; i < digits; i++) {
@@ -54,7 +54,7 @@ void writeFreq(unsigned long freq,byte* cmd) {
   // LSD (1's place), so we ignore that digit.
   byte digits[9];
   getDecimalDigits(freq,digits,9);
-  // Start from the LSB and get each nibble 
+  // Start from the LSB and get each nibble
   cmd[3] = setLowNibble(cmd[3],digits[1]);
   cmd[3] = setHighNibble(cmd[3],digits[2]);
   cmd[2] = setLowNibble(cmd[2],digits[3]);
@@ -62,44 +62,44 @@ void writeFreq(unsigned long freq,byte* cmd) {
   cmd[1] = setLowNibble(cmd[1],digits[5]);
   cmd[1] = setHighNibble(cmd[1],digits[6]);
   cmd[0] = setLowNibble(cmd[0],digits[7]);
-  cmd[0] = setHighNibble(cmd[0],digits[8]);  
+  cmd[0] = setHighNibble(cmd[0],digits[8]);
 }
 
 // This function takes a frquency that is encoded using 4 bytes of BCD
 // representation and turns it into an long measured in Hz.
 //
-// [12][34][56][78] = 123.45678? Mhz
+// [12][34][56][78] = 123.45678? MHz
 //
 unsigned long readFreq(byte* cmd) {
     // Pull off each of the digits
     byte d7 = getHighNibble(cmd[0]);
     byte d6 = getLowNibble(cmd[0]);
     byte d5 = getHighNibble(cmd[1]);
-    byte d4 = getLowNibble(cmd[1]); 
+    byte d4 = getLowNibble(cmd[1]);
     byte d3 = getHighNibble(cmd[2]);
-    byte d2 = getLowNibble(cmd[2]); 
+    byte d2 = getLowNibble(cmd[2]);
     byte d1 = getHighNibble(cmd[3]);
-    byte d0 = getLowNibble(cmd[3]); 
-    return  
+    byte d0 = getLowNibble(cmd[3]);
+    return
       (unsigned long)d7 * 100000000L +
       (unsigned long)d6 * 10000000L +
-      (unsigned long)d5 * 1000000L + 
-      (unsigned long)d4 * 100000L + 
-      (unsigned long)d3 * 10000L + 
-      (unsigned long)d2 * 1000L + 
-      (unsigned long)d1 * 100L + 
-      (unsigned long)d0 * 10L; 
+      (unsigned long)d5 * 1000000L +
+      (unsigned long)d4 * 100000L +
+      (unsigned long)d3 * 10000L +
+      (unsigned long)d2 * 1000L +
+      (unsigned long)d1 * 100L +
+      (unsigned long)d0 * 10L;
 }
 
 /**
  * Responds to all the cat commands, emulates FT-817
  */
-  
+
 void processCATCommand(byte* cmd) {
   byte response[5];
 
   // Debugging code, enable it to fix the cat implementation
-  
+
   count++;
   if (cmd[4] == 0x00){
     response[0]=0;
@@ -107,9 +107,9 @@ void processCATCommand(byte* cmd) {
   }
   else if (cmd[4] == 0x01) {
     unsigned long f = readFreq(cmd);
-    setFrequency(f);   
+    setFrequency(f);
     updateDisplay();
-    //sprintf(b, "set:%ld", f); 
+    //sprintf(b, "set:%ld", f);
     //printLine2(b);
 
   }
@@ -152,7 +152,7 @@ void processCATCommand(byte* cmd) {
       updateDisplay();
     } else {
       response[0] = 0xf0;
-    } 
+    }
     Serial.write(response,1);
     printLine2("rx > tx");
   }
@@ -162,7 +162,7 @@ void processCATCommand(byte* cmd) {
       response[0] = 0;
     } else {
       response[0] = 0xf0;
-    } 
+    }
     Serial.write(response,1);
     printLine2("cat;0x10");
   }
@@ -186,7 +186,7 @@ void processCATCommand(byte* cmd) {
     printLine2("cat;0xe7");
   }
   else if (cmd[4] == 0xf5){
-    
+
   }
   // Read receiver status
   else if (cmd[4] == 0xf7) {
@@ -213,7 +213,7 @@ void processCATCommand(byte* cmd) {
 
 
 void checkCAT(){
-  static byte cat[5]; 
+  static byte cat[5];
   byte i;
 
   if (Serial.available() < 5)
@@ -227,5 +227,3 @@ void checkCAT(){
 
   processCATCommand(cat);
 }
-
-

--- a/ubitx_20/ubitx_menu.ino
+++ b/ubitx_20/ubitx_menu.ino
@@ -1,11 +1,11 @@
 /** Menus
- *  The Radio menus are accessed by tapping on the function button. 
+ *  The Radio menus are accessed by tapping on the function button.
  *  - The main loop() constantly looks for a button press and calls doMenu() when it detects
- *  a function button press. 
+ *  a function button press.
  *  - As the encoder is rotated, at every 10th pulse, the next or the previous menu
  *  item is displayed. Each menu item is controlled by it's own function.
  *  - Eache menu function may be called to display itself
- *  - Each of these menu routines is called with a button parameter. 
+ *  - Each of these menu routines is called with a button parameter.
  *  - The btn flag denotes if the menu itme was clicked on or not.
  *  - If the menu item is clicked on, then it is selected,
  *  - If the menu item is NOT clicked on, then the menu's prompt is to be displayed
@@ -20,7 +20,7 @@ int menuBand(int btn){
 
  // band = frequency/1000000l;
  // offset = frequency % 1000000l;
-    
+
   if (!btn){
    printLine2("Band Select?");
    return;
@@ -30,7 +30,7 @@ int menuBand(int btn){
   //wait for the button menu select button to be lifted)
   while (btnDown())
     delay(50);
-  delay(50);    
+  delay(50);
   ritDisable();
 
   while(!btnDown()){
@@ -41,7 +41,7 @@ int menuBand(int btn){
       if (band > 3 && knob < 0)
         band--;
       if (band < 30 && knob > 0)
-        band++; 
+        band++;
       if (band > 10)
         isUSB = true;
       else
@@ -63,19 +63,19 @@ int menuBand(int btn){
   while(btnDown())
     delay(50);
   delay(50);
-  
+
   printLine2("");
   updateDisplay();
   menuOn = 0;
 }
 
 void menuVfoToggle(int btn){
-  
+
   if (!btn){
     if (vfoActive == VFO_A)
       printLine2("Select VFO B?   ");
     else
-      printLine2("Select VFO A?   ");    
+      printLine2("Select VFO A?   ");
   }
   else {
       if (vfoActive == VFO_B){
@@ -89,10 +89,10 @@ void menuVfoToggle(int btn){
         vfoA = frequency;
         EEPROM.put(VFO_A, frequency);
         vfoActive = VFO_B;
-        printLine2("Selected VFO B  ");      
+        printLine2("Selected VFO B  ");
         frequency = vfoB;
       }
-      
+
       ritDisable();
       setFrequency(frequency);
       if (frequency >= 10000000l)
@@ -151,7 +151,7 @@ void menuSidebandToggle(int btn){
         delay(500);
         printLine2("");
       }
-    
+
     updateDisplay();
     menuOn = 0;
   }
@@ -174,7 +174,7 @@ void menuSetup(int btn){
     }
     else {
       modeCalibrate = false;
-      printLine2("Setup:Off   ");      
+      printLine2("Setup:Off   ");
     }
    delay(2000);
    printLine2("");
@@ -201,7 +201,7 @@ int menuCWSpeed(int btn){
     int wpm;
 
     wpm = 1200/cwSpeed;
-     
+
     if (!btn){
      strcpy(b, "CW:");
      itoa(wpm,c, 10);
@@ -237,7 +237,7 @@ int menuCWSpeed(int btn){
         //re-enable the clock1 and clock 2
         break;
     }
-    
+
     //save the setting
     if (digitalRead(PTT) == LOW){
       printLine2("CW Speed set!");
@@ -253,12 +253,12 @@ int menuCWSpeed(int btn){
 
 /**
  * Take a deep breath, math(ematics) ahead
- * The 25 mhz oscillator is multiplied by 35 to run the vco at 875 mhz
+ * The 25 MHz oscillator is multiplied by 35 to run the vco at 875 MHz
  * This is divided by a number to generate different frequencies.
- * If we divide it by 875, we will get 1 mhz signal
- * So, if the vco is shifted up by 875 hz, the generated frequency of 1 mhz is shifted by 1 hz (875/875)
- * At 12 Mhz, the carrier will needed to be shifted down by 12 hz for every 875 hz of shift up of the vco
- * 
+ * If we divide it by 875, we will get 1 MHz signal
+ * So, if the vco is shifted up by 875 Hz, the generated frequency of 1 MHz is shifted by 1 Hz (875/875)
+ * At 12 MHz, the carrier will needed to be shifted down by 12 Hz for every 875 Hz of shift up of the vco
+ *
  */
 
  //this is used by the si5351 routines in the ubitx_5351 file
@@ -274,7 +274,7 @@ int factoryCalibration(int btn){
   while (btnDown())
     delay(100);
   delay(100);
-   
+
   if (!btn){
     printLine2("Set Calibration?");
     return 0;
@@ -288,12 +288,12 @@ int factoryCalibration(int btn){
   //turn off the second local oscillator and the bfo
   si5351_set_calibration(calibration);
   startTx(TX_CW);
-  si5351bx_setfreq(2, 10000000l); 
-  
+  si5351bx_setfreq(2, 10000000l);
+
   strcpy(b, "#1 10 MHz cal:");
   ltoa(calibration/8750, c, 10);
   strcat(b, c);
-  printLine2(b);     
+  printLine2(b);
 
   while (!btnDown())
   {
@@ -302,22 +302,22 @@ int factoryCalibration(int btn){
       cwKeydown();
     if (digitalRead(PTT)  == HIGH && keyDown)
       cwKeyUp();
-      
+
     knob = enc_read();
 
     if (knob > 0)
       calibration += 875;
     else if (knob < 0)
       calibration -= 875;
-    else 
+    else
       continue; //don't update the frequency or the display
-      
+
     si5351_set_calibration(calibration);
     si5351bx_setfreq(2, 10000000l);
     strcpy(b, "#1 10 MHz cal:");
     ltoa(calibration/8750, c, 10);
     strcat(b, c);
-    printLine2(b);     
+    printLine2(b);
   }
 
   cwTimeout = 0;
@@ -327,7 +327,7 @@ int factoryCalibration(int btn){
   printLine2("Calibration set!");
   EEPROM.put(MASTER_CAL, calibration);
   initOscillators();
-  setFrequency(frequency);    
+  setFrequency(frequency);
   updateDisplay();
 
   while(btnDown())
@@ -338,7 +338,7 @@ int factoryCalibration(int btn){
 int menuSetupCalibration(int btn){
   int knob = 0;
   int32_t prev_calibration;
-   
+
   if (!btn){
     printLine2("Set Calibration?");
     return 0;
@@ -347,16 +347,16 @@ int menuSetupCalibration(int btn){
   printLine1("Set to Zero-beat,");
   printLine2("press PTT to save");
   delay(1000);
-  
+
   prev_calibration = calibration;
   calibration = 0;
   si5351_set_calibration(calibration);
-  setFrequency(frequency);    
-  
+  setFrequency(frequency);
+
   strcpy(b, "cal:");
   ltoa(calibration/8750, c, 10);
   strcat(b, c);
-  printLine2(b);     
+  printLine2(b);
 
   while (digitalRead(PTT) == HIGH && !btnDown())
   {
@@ -375,14 +375,14 @@ int menuSetupCalibration(int btn){
 
     si5351_set_calibration(calibration);
     si5351bx_setfreq(0, usbCarrier);
-    setFrequency(frequency);    
+    setFrequency(frequency);
 
     strcpy(b, "cal:");
     ltoa(calibration/8750, c, 10);
     strcat(b, c);
-    printLine2(b);     
+    printLine2(b);
   }
-  
+
   //save the setting
   if (digitalRead(PTT) == LOW){
     printLine1("Calibration set!");
@@ -396,7 +396,7 @@ int menuSetupCalibration(int btn){
   printLine2("");
   initOscillators();
   //si5351_set_calibration(calibration);
-  setFrequency(frequency);    
+  setFrequency(frequency);
   updateDisplay();
   menuOn = 0;
 }
@@ -408,26 +408,26 @@ void printCarrierFreq(unsigned long freq){
   memset(b, 0, sizeof(b));
 
   ultoa(freq, b, DEC);
-  
+
   strncat(c, b, 2);
   strcat(c, ".");
   strncat(c, &b[2], 3);
   strcat(c, ".");
   strncat(c, &b[5], 1);
-  printLine2(c);    
+  printLine2(c);
 }
 
 void menuSetupCarrier(int btn){
   int knob = 0;
   unsigned long prevCarrier;
-   
+
   if (!btn){
       printLine2("Set the BFO");
     return;
   }
 
   prevCarrier = usbCarrier;
-  printLine1("Tune to best Signal");  
+  printLine1("Tune to best Signal");
   printLine2("PTT to confirm. ");
   delay(1000);
 
@@ -435,7 +435,7 @@ void menuSetupCarrier(int btn){
   si5351bx_setfreq(0, usbCarrier);
   printCarrierFreq(usbCarrier);
 
-  //disable all clock 1 and clock 2 
+  //disable all clock 1 and clock 2
   while (digitalRead(PTT) == HIGH && !btnDown())
   {
     knob = enc_read();
@@ -446,10 +446,10 @@ void menuSetupCarrier(int btn){
       usbCarrier += 50;
     else
       continue; //don't update the frequency or the display
-      
+
     si5351bx_setfreq(0, usbCarrier);
     printCarrierFreq(usbCarrier);
-    
+
     delay(100);
   }
 
@@ -459,32 +459,32 @@ void menuSetupCarrier(int btn){
     EEPROM.put(USB_CAL, usbCarrier);
     delay(1000);
   }
-  else 
+  else
     usbCarrier = prevCarrier;
 
-  si5351bx_setfreq(0, usbCarrier);          
-  setFrequency(frequency);    
+  si5351bx_setfreq(0, usbCarrier);
+  setFrequency(frequency);
   updateDisplay();
   printLine2("");
-  menuOn = 0; 
+  menuOn = 0;
 }
 
 void menuSetupCwTone(int btn){
     int knob = 0;
     int prev_sideTone;
-     
+
     if (!btn){
         printLine2("Change CW Tone");
       return;
     }
 
     prev_sideTone = sideTone;
-    printLine1("Tune CW tone");  
+    printLine1("Tune CW tone");
     printLine2("PTT to confirm. ");
     delay(1000);
     tone(CW_TONE, sideTone);
 
-    //disable all clock 1 and clock 2 
+    //disable all clock 1 and clock 2
     while (digitalRead(PTT) == LOW || !btnDown())
     {
       knob = enc_read();
@@ -495,7 +495,7 @@ void menuSetupCwTone(int btn){
         sideTone -= 10;
       else
         continue; //don't update the frequency or the display
-        
+
       tone(CW_TONE, sideTone);
       itoa(sideTone, b, 10);
       printLine2(b);
@@ -511,10 +511,10 @@ void menuSetupCwTone(int btn){
     }
     else
       sideTone = prev_sideTone;
-    
-    printLine2("");  
-    updateDisplay(); 
-    menuOn = 0; 
+
+    printLine2("");
+    updateDisplay();
+    menuOn = 0;
  }
 
 void doMenu(){
@@ -524,9 +524,9 @@ void doMenu(){
   while(btnDown())
     delay(50);
   delay(50);  //debounce
-  
+
   menuOn = 2;
-  
+
   while (menuOn){
     i = enc_read();
     btnState = btnDown();
@@ -561,7 +561,7 @@ void doMenu(){
     else if (select < 100 && modeCalibrate)
       menuSetupCwTone(btnState);
     else if (select < 110 && modeCalibrate)
-      menuExit(btnState);  
+      menuExit(btnState);
   }
 
   //debounce the button
@@ -569,4 +569,3 @@ void doMenu(){
     delay(50);
   delay(50);
 }
-

--- a/ubitx_20/ubitx_si5351.ino
+++ b/ubitx_20/ubitx_si5351.ino
@@ -1,9 +1,9 @@
 // *************  SI5315 routines - tks Jerry Gaffke, KE7ER   ***********************
 
 // An minimalist standalone set of Si5351 routines.
-// VCOA is fixed at 875mhz, VCOB not used.
+// VCOA is fixed at 875MHz, VCOB not used.
 // The output msynth dividers are used to generate 3 independent clocks
-// with 1hz resolution to any frequency between 4khz and 109mhz.
+// with 1Hz resolution to any frequency between 4kHz and 109MHz.
 
 // Usage:
 // Call si5351bx_init() once at startup with no args;
@@ -12,14 +12,14 @@
 // A freq of 0 serves to shut down that output clock.
 
 // The global variable si5351bx_vcoa starts out equal to the nominal VCOA
-// frequency of 25mhz*35 = 875000000 Hz.  To correct for 25mhz crystal errors,
+// frequency of 25MHz*35 = 875000000 Hz.  To correct for 25MHz crystal errors,
 // the user can adjust this value.  The vco frequency will not change but
 // the number used for the (a+b/c) output msynth calculations is affected.
-// Example:  We call for a 5mhz signal, but it measures to be 5.001mhz.
-// So the actual vcoa frequency is 875mhz*5.001/5.000 = 875175000 Hz,
+// Example:  We call for a 5MHz signal, but it measures to be 5.001MHz.
+// So the actual vcoa frequency is 875MHz*5.001/5.000 = 875175000 Hz,
 // To correct for this error:     si5351bx_vcoa=875175000;
 
-// Most users will never need to generate clocks below 500khz.
+// Most users will never need to generate clocks below 500kHz.
 // But it is possible to do so by loading a value between 0 and 7 into
 // the global variable si5351bx_rdiv, be sure to return it to a value of 0
 // before setting some other CLK output pin.  The affected clock will be
@@ -35,12 +35,12 @@
 #define SI5351BX_ADDR 0x60              // I2C address of Si5351   (typical)
 #define SI5351BX_XTALPF 2               // 1:6pf  2:8pf  3:10pf
 
-// If using 27mhz crystal, set XTAL=27000000, MSA=33.  Then vco=891mhz
+// If using 27MHz crystal, set XTAL=27000000, MSA=33.  Then vco=891MHz
 #define SI5351BX_XTAL 25000000          // Crystal freq in Hz
-#define SI5351BX_MSA  35                // VCOA is at 25mhz*35 = 875mhz
+#define SI5351BX_MSA  35                // VCOA is at 25MHz*35 = 875MHz
 
 // User program may have reason to poke new values into these 3 RAM variables
-uint32_t si5351bx_vcoa = (SI5351BX_XTAL*SI5351BX_MSA);  // 25mhzXtal calibrate
+uint32_t si5351bx_vcoa = (SI5351BX_XTAL*SI5351BX_MSA);  // 25MHzXtal calibrate
 uint8_t  si5351bx_rdiv = 0;             // 0-7, CLK pin sees fout/(2**rdiv)
 uint8_t  si5351bx_drive[3] = {1, 1, 1}; // 0=2ma 1=4ma 2=6ma 3=8ma for CLK 0,1,2
 uint8_t  si5351bx_clken = 0xFF;         // Private, all CLK output drivers off
@@ -66,7 +66,7 @@ void si5351bx_init() {                  // Call once at power-up, start PLLA
   Wire.begin();
   i2cWrite(149, 0);                     // SpreadSpectrum off
   i2cWrite(3, si5351bx_clken);          // Disable all CLK output drivers
-  i2cWrite(183, SI5351BX_XTALPF << 6);  // Set 25mhz crystal load capacitance
+  i2cWrite(183, SI5351BX_XTALPF << 6);  // Set 25MHz crystal load capacitance
   msxp1 = 128 * SI5351BX_MSA - 512;     // and msxp2=0, msxp3=1, not fractional
   uint8_t  vals[8] = {0, 1, BB2(msxp1), BB1(msxp1), BB0(msxp1), 0, 0, 0};
   i2cWriten(26, vals, 8);               // Write to 8 PLLA msynth regs
@@ -111,6 +111,3 @@ void initOscillators(){
   si5351bx_vcoa = (SI5351BX_XTAL * SI5351BX_MSA) + calibration; // apply the calibration correction factor
   si5351bx_setfreq(0, usbCarrier);
 }
-
-
-

--- a/ubitx_20/ubitx_ui.ino
+++ b/ubitx_20/ubitx_ui.ino
@@ -2,7 +2,7 @@
  * The user interface of the ubitx consists of the encoder, the push-button on top of it
  * and the 16x2 LCD display.
  * The upper line of the display is constantly used to display frequency and status
- * of the radio. Occasionally, it is used to provide a two-line information that is 
+ * of the radio. Occasionally, it is used to provide a two-line information that is
  * quickly cleared up.
  */
 
@@ -17,8 +17,8 @@ int btnDown(){
 /**
  * Meter (not used in this build for anything)
  * the meter is drawn using special characters. Each character is composed of 5 x 8 matrix.
- * The  s_meter array holds the definition of the these characters. 
- * each line of the array is is one character such that 5 bits of every byte 
+ * The  s_meter array holds the definition of the these characters.
+ * each line of the array is is one character such that 5 bits of every byte
  * makes up one line of pixels of the that character (only 5 bits are used)
  * The current reading of the meter is assembled in the string called meter
  */
@@ -74,7 +74,7 @@ void drawMeter(int8_t needle){
   meter[i] = 0;
 }
 
-// The generic routine to display one line on the LCD 
+// The generic routine to display one line on the LCD
 void printLine(char linenmbr, char *c) {
   if (strcmp(c, printBuff[linenmbr])) {     // only refresh the display when there was a change
     lcd.setCursor(0, linenmbr);             // place the cursor at the beginning of the selected line
@@ -129,12 +129,12 @@ void updateDisplay() {
 
 
 
-  //one mhz digit if less than 10 M, two digits if more
+  //one MHz digit if less than 10 M, two digits if more
   if (frequency < 10000000l){
     c[6] = ' ';
     c[7]  = b[0];
     strcat(c, ".");
-    strncat(c, &b[1], 3);    
+    strncat(c, &b[1], 3);
     strcat(c, ".");
     strncat(c, &b[4], 3);
   }
@@ -143,7 +143,7 @@ void updateDisplay() {
     strcat(c, ".");
     strncat(c, &b[2], 3);
     strcat(c, ".");
-    strncat(c, &b[5], 3);    
+    strncat(c, &b[5], 3);
   }
 
   if (inTx)
@@ -172,16 +172,16 @@ int enc_prev_state = 3;
 /**
  * The A7 And A6 are purely analog lines on the Arduino Nano
  * These need to be pulled up externally using two 10 K resistors
- * 
+ *
  * There are excellent pages on the Internet about how these encoders work
  * and how they should be used. We have elected to use the simplest way
- * to use these encoders without the complexity of interrupts etc to 
+ * to use these encoders without the complexity of interrupts etc to
  * keep it understandable.
- * 
+ *
  * The enc_state returns a two-bit number such that each bit reflects the current
  * value of each of the two phases of the encoder
- * 
- * The enc_read returns the number of net pulses counted over 50 msecs. 
+ *
+ * The enc_read returns the number of net pulses counted over 50 msecs.
  * If the puluses are -ve, they were anti-clockwise, if they are +ve, the
  * were in the clockwise directions. Higher the pulses, greater the speed
  * at which the enccoder was spun
@@ -192,31 +192,31 @@ byte enc_state (void) {
 }
 
 int enc_read(void) {
-  int result = 0; 
+  int result = 0;
   byte newState;
   int enc_speed = 0;
-  
+
   long stop_by = millis() + 50;
-  
+
   while (millis() < stop_by) { // check if the previous state was stable
-    newState = enc_state(); // Get current state  
-    
+    newState = enc_state(); // Get current state
+
     if (newState != enc_prev_state)
       delay (1);
-    
+
     if (enc_state() != newState || newState == enc_prev_state)
-      continue; 
+      continue;
     //these transitions point to the encoder being rotated anti-clockwise
-    if ((enc_prev_state == 0 && newState == 2) || 
-      (enc_prev_state == 2 && newState == 3) || 
-      (enc_prev_state == 3 && newState == 1) || 
+    if ((enc_prev_state == 0 && newState == 2) ||
+      (enc_prev_state == 2 && newState == 3) ||
+      (enc_prev_state == 3 && newState == 1) ||
       (enc_prev_state == 1 && newState == 0)){
         result--;
       }
     //these transitions point o the enccoder being rotated clockwise
-    if ((enc_prev_state == 0 && newState == 1) || 
-      (enc_prev_state == 1 && newState == 3) || 
-      (enc_prev_state == 3 && newState == 2) || 
+    if ((enc_prev_state == 0 && newState == 1) ||
+      (enc_prev_state == 1 && newState == 3) ||
+      (enc_prev_state == 3 && newState == 2) ||
       (enc_prev_state == 2 && newState == 0)){
         result++;
       }
@@ -226,5 +226,3 @@ int enc_read(void) {
   }
   return(result);
 }
-
-


### PR DESCRIPTION
Hi

I saw a misspelling of "transceiver" in the README file, so I fixed that.  While I was at it I looked through the code for the transceiver control, and saw that the decadic prefixes Kilo and Mega were abbreviated inconsistently and often incorrectly.  As was the abbreviation for Hertz.    Edited these to be consistent, and to be conformant to:

  *   https://en.wikipedia.org/wiki/Metric_prefix
  *   https://en.wikipedia.org/wiki/Hertz

Only documentation files or fields were changed.  No code that actually compiles into anything
was touched during this edit.

Awsome project!  Wonderful idea and fantastic execution.  I may build one myself :)

Best wishes.  73, de LA3LMA
