### PR TITLE
Fixed a simple bug where the cw side tone did not change on uBITX Transceiver

### DIFF
--- a/ubitx_20/ubitx_menu.ino
+++ b/ubitx_20/ubitx_menu.ino
@@ -485,7 +485,7 @@ void menuSetupCwTone(int btn){
     tone(CW_TONE, sideTone);
 
     //disable all clock 1 and clock 2 
-    while (digitalRead(PTT) == LOW || !btnDown())
+    while (digitalRead(PTT) == HIGH && !btnDown())
     {
       knob = enc_read();
 
@@ -506,7 +506,7 @@ void menuSetupCwTone(int btn){
     //save the setting
     if (digitalRead(PTT) == LOW){
       printLine2("Sidetone set!    ");
-      EEPROM.put(CW_SIDETONE, usbCarrier);
+      EEPROM.put(CW_SIDETONE, sideTone);
       delay(2000);
     }
     else


### PR DESCRIPTION
Dear afarhan

I found a minor bug and made the following changes:
I downloaded uBITX 2.0 source code and compiled it.

1.There is no response when PTT is pressed after CW side tone is set.
https://www.youtube.com/watch?v=1EPPknBQNLY

2.It works perfectly, However, the changed side tone is initialized when the power is turned off and on again.
https://www.youtube.com/watch?v=5eZyQAyrsvM

This simple problem can also be easily corrected.


3.It works perfectly all, change to cw side band (pitch), save to eeprom.
https://www.youtube.com/watch?v=wMFvJ33JS1I

modified just 2 lines

thank afarhan for making this very fun uBITX and good performance.

For a happy ham life with uBITX

Best 73
DE KD8CEC / Ph.D Ian lee
kd8cec@gmail.com